### PR TITLE
test: add coverage for decision constants and NoopStore

### DIFF
--- a/sidecar/internal/state/noop_test.go
+++ b/sidecar/internal/state/noop_test.go
@@ -1,0 +1,52 @@
+package state
+
+import "testing"
+
+func TestNoopStore_GetReturnsNil(t *testing.T) {
+	store := &NoopStore{}
+	result := store.Get("any-session-id")
+	if result != nil {
+		t.Errorf("NoopStore.Get should return nil, got %v", result)
+	}
+}
+
+func TestNoopStore_GetDifferentKeys(t *testing.T) {
+	store := &NoopStore{}
+	keys := []string{"session-1", "session-2", "", "abc-123"}
+	for _, key := range keys {
+		if store.Get(key) != nil {
+			t.Errorf("NoopStore.Get(%q) should return nil", key)
+		}
+	}
+}
+
+func TestNoopStore_SetDoesNotPanic(t *testing.T) {
+	store := &NoopStore{}
+	// Set should be a no-op — must not panic on any input
+	store.Set("session-1", "some-value")
+	store.Set("", nil)
+	store.Set("key", map[string]any{"score": 0.5})
+}
+
+func TestNoopStore_SetThenGetReturnsNil(t *testing.T) {
+	store := &NoopStore{}
+	store.Set("session-1", "stored-value")
+	result := store.Get("session-1")
+	if result != nil {
+		t.Errorf("NoopStore is stateless — Get after Set should still return nil, got %v", result)
+	}
+}
+
+func TestNoopStore_Stateless(t *testing.T) {
+	// Verify that NoopStore maintains no state between calls
+	store := &NoopStore{}
+	store.Set("s1", "val1")
+	store.Set("s2", "val2")
+	store.Set("s3", "val3")
+
+	for _, key := range []string{"s1", "s2", "s3"} {
+		if store.Get(key) != nil {
+			t.Errorf("NoopStore should be stateless, Get(%q) returned non-nil", key)
+		}
+	}
+}

--- a/sidecar/pkg/decision/decision_test.go
+++ b/sidecar/pkg/decision/decision_test.go
@@ -1,0 +1,37 @@
+package decision
+
+import "testing"
+
+func TestDecisionConstants_UniqueValues(t *testing.T) {
+	if Allow == Sanitise || Allow == Block || Sanitise == Block {
+		t.Fatal("decision constants must have unique values")
+	}
+}
+
+func TestDecisionConstants_ExpectedBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		got      byte
+		expected byte
+	}{
+		{"Allow", Allow, 0x00},
+		{"Sanitise", Sanitise, 0x01},
+		{"Block", Block, 0x02},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.expected {
+				t.Errorf("%s = 0x%02x, want 0x%02x", tt.name, tt.got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecisionConstants_SingleByte(t *testing.T) {
+	// Verify all decisions fit in a single byte (wire protocol requirement)
+	for _, d := range []byte{Allow, Sanitise, Block} {
+		if d > 0xFF {
+			t.Errorf("decision 0x%02x exceeds single byte", d)
+		}
+	}
+}


### PR DESCRIPTION
**`pkg/decision/decision_test.go`** (3 tests)
- Wire protocol constants have unique values
- Byte values match expected encoding (Allow=0x00, Sanitise=0x01, Block=0x02)
- All constants fit single byte (wire protocol constraint)

**`internal/state/noop_test.go`** (5 tests)
- Get returns nil for any key
- Get returns nil across different session IDs
- Set accepts any input without panic
- Set-then-Get still returns nil (stateless guarantee)
- Multiple Set calls maintain no state

All 57 sidecar tests passing. No code modified — tests only.