### PR TITLE
fix(normalise): sort map keys before joining for deterministic `CanonicalText`  

### DIFF
--- a/sidecar/internal/pipeline/normalise.go
+++ b/sidecar/internal/pipeline/normalise.go
@@ -14,6 +14,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -74,10 +75,17 @@ func payloadText(payload any) string {
 		return v
 	case map[string]any:
 		// For structured payloads (on_tool_call, on_context), concatenate all
-		// string values for scanning purposes.
+		// string values in sorted key order for a deterministic CanonicalText.
+		// Go map iteration is random — without sorting, the same payload can
+		// produce different CanonicalText across runs, causing flaky scan results.
+		keys := make([]string, 0, len(v))
+		for k := range v {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 		var parts []string
-		for _, val := range v {
-			if s, ok := val.(string); ok {
+		for _, k := range keys {
+			if s, ok := v[k].(string); ok {
 				parts = append(parts, s)
 			}
 		}

--- a/sidecar/internal/pipeline/normalise_test.go
+++ b/sidecar/internal/pipeline/normalise_test.go
@@ -75,6 +75,43 @@ func TestNormalise_OriginalPayloadUnchanged(t *testing.T) {
 	}
 }
 
+func TestNormalise_MapPayloadDeterministic(t *testing.T) {
+	n := NewNormaliseStage()
+	payload := map[string]any{
+		"name": "shell",
+		"args": "rm -rf /",
+	}
+	// Run 10 times — CanonicalText must be identical every time.
+	var first string
+	for i := 0; i < 10; i++ {
+		rc := &riskcontext.RiskContext{Payload: payload}
+		n.Run(rc)
+		if i == 0 {
+			first = rc.CanonicalText
+			continue
+		}
+		if rc.CanonicalText != first {
+			t.Errorf("non-deterministic CanonicalText: run 0 got %q, run %d got %q", first, i, rc.CanonicalText)
+		}
+	}
+}
+
+func TestNormalise_MapPayloadSortedKeyOrder(t *testing.T) {
+	n := NewNormaliseStage()
+	rc := &riskcontext.RiskContext{
+		Payload: map[string]any{
+			"name": "shell",
+			"args": "rm -rf /",
+		},
+	}
+	n.Run(rc)
+	// keys sorted: "args" < "name" → values joined in that order
+	want := "rm -rf / shell"
+	if rc.CanonicalText != want {
+		t.Errorf("expected %q, got %q", want, rc.CanonicalText)
+	}
+}
+
 func TestNormalise_MapPayload(t *testing.T) {
 	n := NewNormaliseStage()
 	rc := &riskcontext.RiskContext{


### PR DESCRIPTION
## Problem
 
In `normalise.go`, `payloadText` processes structured payloads (`map[string]any`) by iterating over the map and concatenating string values. Go map iteration order is non-deterministic, meaning the same input can produce different `CanonicalText` across runs.
 
**Example** — `{"name": "shell", "args": "rm -rf /"}` may produce:
 
```
"shell rm -rf /"
```
 
or:
 
```
"rm -rf / shell"
```
 
depending on iteration order. If a jailbreak pattern spans a field boundary, whether Aho-Corasick matches it depends on which order the fields are joined, leading to inconsistent scan results for identical input.
 
---
 
## Fix
 
Collect map keys, sort them using `sort.Strings`, then iterate in sorted order before joining:
 
```go
keys := make([]string, 0, len(v))
for k := range v {
    keys = append(keys, k)
}
sort.Strings(keys)
 
for _, k := range keys {
    if s, ok := v[k].(string); ok {
        parts = append(parts, s)
    }
}
```
 
`{"name": "shell", "args": "rm -rf /"}` now **always** produces:
 
```
"rm -rf / shell"
```
 
*(alphabetical key order: `args < name`)*
 
---
 
## Tests Added
 
| Test | Description |
|---|---|
| `TestNormalise_MapPayloadDeterministic` | Verifies that the same payload run multiple times produces identical `CanonicalText` |
| `TestNormalise_MapPayloadSortedKeyOrder` | Asserts output follows sorted key order |
 
### Test Results
 
```
=== RUN   TestNormalise_MapPayloadDeterministic
--- PASS: TestNormalise_MapPayloadDeterministic (0.00s)
=== RUN   TestNormalise_MapPayloadSortedKeyOrder
--- PASS: TestNormalise_MapPayloadSortedKeyOrder (0.00s)
 
ok  github.com/acf-sdk/sidecar/internal/pipeline
```
 
All tests pass. No regressions observed.
  
closes #48 