### PR TITLE
fix(policies): tool allowlist empty-array handling + memory jailbreak detection

### DIFF
--- a/policies/v1/memory.rego
+++ b/policies/v1/memory.rego
@@ -108,3 +108,7 @@ _has_content_scan_signal if {
     sig.category == "content_scan"
     sig.score >= 0.5
 }
+_has_content_scan_signal if {
+    some sig in input.signals
+    sig.category == "jailbreak_pattern"
+}

--- a/policies/v1/tool.rego
+++ b/policies/v1/tool.rego
@@ -75,6 +75,9 @@ _tool_is_permitted if {
 _tool_is_permitted if {
     not data.config.tool_allowlist
 }
+_tool_is_permitted if {
+    count(data.config.tool_allowlist) == 0
+}
 
 # Destination allowlist: destination must be listed, or no destination
 # in the request, or no allowlist configured


### PR DESCRIPTION
## fix(policies): align tool allowlist and memory detection with Phase 3 signal format

Found two issues while testing the Phase 3 examples end-to-end.

### Bug 1 — Tool calls blocked when no allowlist configured

`_tool_is_permitted` checked `not data.config.tool_allowlist` to detect an unconfigured allowlist. But when the config has an empty array `[]`, Rego treats it as truthy — so the check failed and all tools fell through to default BLOCK, including `search` and `calculator`.

Fix: added `count(data.config.tool_allowlist) == 0` as an additional permitted condition.

Before: `search` → BLOCK
After: `search` → ALLOW

### Bug 2 — Memory jailbreak writes not detected

`_has_content_scan_signal` only matched `sig.category == "content_scan"`, but the Phase 3 scan stage emits `"jailbreak_pattern"` as the signal category. Memory writes containing jailbreak patterns were passing through undetected.

Fix: added `sig.category == "jailbreak_pattern"` as an additional match in `_has_content_scan_signal`.

Before: `write "Ignore all previous instructions"` → ALLOW
After: `write "Ignore all previous instructions"` → SANITISE

### Tests

54/54 OPA tests passing. All Go sidecar tests passing. All 7 examples verified end-to-end.