### PR TITLE
remove jp-009, it never fires

### DIFF
--- a/policies/v1/data/jailbreak_patterns.json
+++ b/policies/v1/data/jailbreak_patterns.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Versioned jailbreak pattern library. Update independently of Rego rules.",
-  "_version": "2.1.0",
+  "_version": "2.1.1",
   "patterns": [
     {
       "id": "jp-001",
@@ -57,14 +57,6 @@
       "pattern": "the admin has authorized",
       "severity": "medium",
       "owasp_llm": "LLM01"
-    },
-    {
-      "id": "jp-009",
-      "category": "encoding_bypass",
-      "pattern": "aWdub3JlIHByZXZpb3VzIGluc3RydWN0aW9ucw==",
-      "severity": "high",
-      "owasp_llm": "LLM01",
-      "note": "base64 encoded 'ignore previous instructions'"
     },
     {
       "id": "jp-010",


### PR DESCRIPTION
tharindu flagged on #26 that jp-009 doesn't seem to fire, and it doesn't

it's the base64 for "ignore previous instructions". normalise decodes base64 in stage 2 before the scan stage runs, so when the whole payload is the encoded string it's already decoded by the time we match and jp-001 catches the plain text. embedded in a longer prompt the leetspeak step rewrites the digits (3->e, 0->o) so the literal can't match there either. just dead weight, pulling it

checked it against the normalise stage to be sure:
- whole payload ends up as `ignore previous instructions` -> jp-001 fires
- embedded ends up mangled, no match

opa still 96/96, build and tests green, bumped to 2.1.1

one follow-up worth a separate issue: embedded base64 isn't covered by anything right now since we only decode a whole-payload token. token-level decode in normalise would fix that and drop the need for the literal encoded patterns
