### PR TITLE
fix(policy): fail-closed memory reads when HMAC proof is absent

### DIFF
--- a/policies/tests/memory_test.rego
+++ b/policies/tests/memory_test.rego
@@ -35,6 +35,17 @@ test_read_hmac_valid_allow if {
 	result == "ALLOW"
 }
 
+test_read_missing_integrity_block if {
+	result := memory.decision with input as {
+		"memory_op": "read",
+		"score": 0.0,
+		"signals": [],
+		"provenance": "agent", "session_id": "m-009", "hook_type": "on_memory",
+		"payload_size_bytes": 100,
+	}
+	result == "BLOCK"
+}
+
 # --- Detection: write-time content scan ---
 
 # A poisoned write flagged by the content scanner is stripped (SANITISE).

--- a/policies/v1/memory.rego
+++ b/policies/v1/memory.rego
@@ -26,7 +26,7 @@ default decision := "ALLOW"
 
 decision := "BLOCK" if {
     input.memory_op == "read"
-    input.integrity.hmac_valid == false
+    not input.integrity.hmac_valid == true
 }
 
 # ---------------------------------------------------------------------

--- a/policies/v1/memory_test.rego
+++ b/policies/v1/memory_test.rego
@@ -35,6 +35,29 @@ test_read_invalid_hmac_block if {
     result == "BLOCK"
 }
 
+test_read_missing_hmac_block if {
+    result := memory.decision with input as {
+        "memory_op": "read",
+        "score": 0.0,
+        "signals": [],
+        "provenance": "agent", "session_id": "s1", "hook_type": "on_memory",
+        "payload_size_bytes": 100,
+    }
+    result == "BLOCK"
+}
+
+test_read_null_hmac_block if {
+    result := memory.decision with input as {
+        "memory_op": "read",
+        "score": 0.0,
+        "signals": [],
+        "provenance": "agent", "session_id": "s1", "hook_type": "on_memory",
+        "integrity": {"hmac_valid": null},
+        "payload_size_bytes": 100,
+    }
+    result == "BLOCK"
+}
+
 # =====================================================================
 # Integrity — write-time HMAC stamp
 # =====================================================================


### PR DESCRIPTION
## what

memory.rego checked hmac_valid with `== false`, which only matched an explicit false.
reads where the integrity object was missing or hmac_valid was null fell through to
the default ALLOW, making the HMAC verification gate fail-open.

switched to `not input.integrity.hmac_valid == true` so undefined, null, and false
all produce BLOCK. this is the standard Rego fail-closed pattern.

## why

gap #2 from the coverage analysis posted Jul 8 (23 open gaps, hook-level matrix in
\#acf-sdk). the integration harness probe ap-107 flagged this: "an absent integrity
proof on read is treated as valid (null is not false), so memory reads fail open."

## changes

- `policies/v1/memory.rego`: 1-line fix (line 29)
- `policies/v1/memory_test.rego`: 2 new tests (missing integrity, null hmac_valid)
- `policies/tests/memory_test.rego`: 1 new adversarial test (missing integrity)

## testing

- opa test 99/99 (was 96/96 before the new tests)
- go test ./... all pass
- go vet clean
- truth table verified: hmac_valid=true -> ALLOW, hmac_valid=false -> BLOCK,
  hmac_valid=null -> BLOCK, missing integrity -> BLOCK

## follow-up

ap-107 in the integration harness should be marked `closed: true` after this merges
so the ratchet asserts BLOCK strictly going forward