### PR TITLE
fix: activate destination allowlist gate in policy config

### DIFF
--- a/policies/tests/tool_test.rego
+++ b/policies/tests/tool_test.rego
@@ -140,6 +140,39 @@ test_threshold_medium_sanitise if {
 	result == "SANITISE"
 }
 
+# --- Permission: destination gate with configured allowlist ---
+
+# An allowed tool calling an unlisted destination is blocked when the
+# allowlist is present. This is the production-config scenario: the sidecar
+# loads policy_config.yaml as data.config (engine.go:229). Before this fix,
+# the key was absent from policy_config.yaml so the gate was permanently open.
+test_destination_gate_blocks_unlisted if {
+	result := tool.decision with input as {
+		"tool_name": "http_request",
+		"score": 0.1,
+		"signals": [],
+		"provenance": "agent", "session_id": "t-013", "hook_type": "on_tool_call",
+		"tool_metadata": {"destination": "evil.exfil.example"},
+	}
+		with data.config.tool_allowlist as ["http_request"]
+		with data.config.destination_allowlist as ["api.example.com", "cdn.example.com"]
+	result == "BLOCK"
+}
+
+# A tool call with no destination field passes regardless of allowlist config.
+test_no_destination_field_passes if {
+	result := tool.decision with input as {
+		"tool_name": "calculator",
+		"score": 0.1,
+		"signals": [],
+		"provenance": "agent", "session_id": "t-014", "hook_type": "on_tool_call",
+		"tool_metadata": {},
+	}
+		with data.config.tool_allowlist as ["calculator"]
+		with data.config.destination_allowlist as ["api.example.com"]
+	result == "ALLOW"
+}
+
 # --- False-positive / boundary guards ---
 
 # A detection signal below the 0.5 confidence cut is not treated as a hit.

--- a/policies/v1/data/policy_config.yaml
+++ b/policies/v1/data/policy_config.yaml
@@ -20,6 +20,10 @@ tool_allowlist:          # tools permitted by allowlist gate; empty = block all;
 
 memory_key_allowlist: [] # permitted memory keys; empty = allow all
 
+destination_allowlist:    # permitted network destinations for tool calls; omit key = allow all
+  - api.example.com
+  - cdn.example.com
+
 signal_weights:          # per-signal contribution to risk score
   jailbreak_pattern: 0.9
   instruction_override: 0.85

--- a/policies/v1/tool_test.rego
+++ b/policies/v1/tool_test.rego
@@ -63,6 +63,19 @@ test_allowed_destination_passes if {
     result == "ALLOW"
 }
 
+test_no_destination_ignores_allowlist if {
+    result := tool.decision with input as {
+        "tool_name": "calculator",
+        "score": 0.1,
+        "signals": [],
+        "provenance": "sdk", "session_id": "s1", "hook_type": "on_tool_call",
+        "tool_metadata": {},
+    }
+        with data.config.tool_allowlist as ["calculator"]
+        with data.config.destination_allowlist as ["api.example.com"]
+    result == "ALLOW"
+}
+
 test_blocked_destination_denied if {
     result := tool.decision with input as {
         "tool_name": "http_request",

--- a/sidecar/internal/policy/engine_test.go
+++ b/sidecar/internal/policy/engine_test.go
@@ -174,6 +174,54 @@ func TestEngine_OnToolCall_DefaultBLOCK_WhenNotOnAllowlist(t *testing.T) {
 	}
 }
 
+func TestEngine_OnToolCall_DestinationAllowlist_Blocks(t *testing.T) {
+	eng := newTestEngine(t)
+	rc := &riskcontext.RiskContext{
+		HookType:   "on_tool_call",
+		Provenance: "agent",
+		Score:      0.0,
+		Signals:    nil,
+		Payload: map[string]any{
+			"name":   "search",
+			"params": map[string]any{},
+			"metadata": map[string]any{
+				"destination": "evil.exfil.example",
+			},
+		},
+	}
+	decision, _, err := eng.Evaluate(rc)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision != "BLOCK" {
+		t.Errorf("expected BLOCK for unlisted destination, got %q", decision)
+	}
+}
+
+func TestEngine_OnToolCall_DestinationAllowlist_Allows(t *testing.T) {
+	eng := newTestEngine(t)
+	rc := &riskcontext.RiskContext{
+		HookType:   "on_tool_call",
+		Provenance: "agent",
+		Score:      0.0,
+		Signals:    nil,
+		Payload: map[string]any{
+			"name":   "search",
+			"params": map[string]any{},
+			"metadata": map[string]any{
+				"destination": "api.example.com",
+			},
+		},
+	}
+	decision, _, err := eng.Evaluate(rc)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if decision != "ALLOW" {
+		t.Errorf("expected ALLOW for listed destination, got %q", decision)
+	}
+}
+
 func TestEngine_OnMemory_BLOCK_InvalidHMAC(t *testing.T) {
 	eng := newTestEngine(t)
 	rc := &riskcontext.RiskContext{


### PR DESCRIPTION
## Summary

The `destination_allowlist` key was absent from `policy_config.yaml`, causing `tool.rego` `_destination_is_permitted` to evaluate `not undefined` as `true` -- the network-destination gate was permanently open. Tool calls to any external destination were unconditionally permitted regardless of the Rego rule logic.

The fix adds the key with example hosts (`api.example.com`, `cdn.example.com`), activating the fully-written and tested allowlist gate. Operators should customize these values before deploying.

### Root cause

`engine.go:229` maps `policy_config.yaml` to `data.config` in OPA. `tool.rego:85-86` has:

```rego
_destination_is_permitted if {
    not data.config.destination_allowlist
}
```

With the key absent, `data.config.destination_allowlist` is undefined, `not undefined` evaluates to `true`, and `_destination_is_permitted` is always satisfied. This bypasses the destination check at `tool.rego:89-93` which validates `input.tool_metadata.destination in data.config.destination_allowlist`.

### Changes

- `policies/v1/data/policy_config.yaml`: add `destination_allowlist` with example hosts
- `policies/v1/tool_test.rego`: add unit test for no-destination pass-through
- `policies/tests/tool_test.rego`: add 2 adversarial tests (unlisted destination blocks, no-destination passes)
- `sidecar/internal/policy/engine_test.go`: add 2 Go integration tests that load the real `policy_config.yaml` and verify the gate

### Test results

- OPA: 99/99 pass
- Go: all pass (including 2 new integration tests against the real config)
- `go vet`: clean