### PR TITLE
feat(adapters): add Agent Kernel guardrail adapter

### DIFF
--- a/sdk/python/acf/adapters/__init__.py
+++ b/sdk/python/acf/adapters/__init__.py
@@ -1,1 +1,1 @@
-"""Optional framework adapters — LangGraph and LangChain."""
+"""Optional framework adapters — LangGraph, LangChain, and Agent Kernel."""

--- a/sdk/python/acf/adapters/agent_kernel.py
+++ b/sdk/python/acf/adapters/agent_kernel.py
@@ -1,0 +1,181 @@
+"""
+Agent Kernel guardrail adapter for ACF-SDK.
+
+Integrates the ACF firewall as an InputGuardrail and OutputGuardrail in
+Agent Kernel's guardrail system. Sits alongside OpenAI and Bedrock as a
+guardrail option — but runs locally, deterministically, with no API calls.
+
+Usage in Agent Kernel config:
+
+    guardrails:
+      input:
+        provider: acf
+      output:
+        provider: acf
+
+Or programmatically:
+
+    from acf.adapters.agent_kernel import ACFInputGuardrail, ACFOutputGuardrail
+
+    input_guard = ACFInputGuardrail(firewall=fw)
+    output_guard = ACFOutputGuardrail(firewall=fw)
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from ..firewall import Firewall
+from ..models import Decision, SanitiseResult, FirewallError
+
+logger = logging.getLogger(__name__)
+
+try:
+    from agentkernel.guardrail.guardrail import (
+        BaseGuardrailUtil,
+        GuardrailAction,
+        GuardrailResult,
+        InputGuardrail,
+        InputGuardrailFactory,
+        OutputGuardrail,
+        OutputGuardrailFactory,
+    )
+    from agentkernel.core.model import (
+        AgentReplyAny,
+        AgentReplyText,
+        AgentRequestText,
+    )
+    from agentkernel.core.base import Agent, Session
+
+    _AK_AVAILABLE = True
+except ImportError:
+    _AK_AVAILABLE = False
+
+
+def _check_ak():
+    if not _AK_AVAILABLE:
+        raise ImportError(
+            "Agent Kernel is not installed. Install with: pip install agentkernel"
+        )
+
+
+class ACFInputGuardrail(InputGuardrail if _AK_AVAILABLE else object):
+    """ACF firewall as an Agent Kernel input guardrail.
+
+    Runs fw.on_prompt() on each incoming request. Maps ACF decisions to
+    Agent Kernel's GuardrailAction:
+        Decision.ALLOW    -> GuardrailAction.ALLOW
+        Decision.BLOCK    -> GuardrailAction.BLOCK
+        SanitiseResult    -> GuardrailAction.OVERRIDE (cleaned text)
+    """
+
+    def __init__(self, firewall: Optional[Firewall] = None, **kwargs):
+        _check_ak()
+        super().__init__(**kwargs)
+        self._firewall = firewall or Firewall()
+
+    def validate(
+        self,
+        agent: Agent,
+        session: Session,
+        requests: List[AgentRequestText],
+    ) -> GuardrailResult:
+        """Check each request through the ACF firewall."""
+        for request in requests:
+            text = getattr(request, "prompt", None)
+            if not text or not isinstance(text, str):
+                continue
+
+            try:
+                result = self._firewall.on_prompt(text)
+            except FirewallError as e:
+                logger.warning("acf-sdk: guardrail error on input: %s", e)
+                # Fail-closed: block on firewall errors.
+                return GuardrailResult(
+                    action=GuardrailAction.BLOCK,
+                    message=f"ACF firewall error: {e}",
+                )
+
+            if isinstance(result, SanitiseResult):
+                request.prompt = result.sanitised_text
+                return GuardrailResult(
+                    action=GuardrailAction.OVERRIDE,
+                    override_text=result.sanitised_text,
+                    message="ACF: input sanitised",
+                )
+
+            if result == Decision.BLOCK:
+                return GuardrailResult(
+                    action=GuardrailAction.BLOCK,
+                    message="ACF: input blocked by firewall policy",
+                )
+
+        return GuardrailResult(action=GuardrailAction.ALLOW)
+
+
+class ACFOutputGuardrail(OutputGuardrail if _AK_AVAILABLE else object):
+    """ACF firewall as an Agent Kernel output guardrail.
+
+    Runs fw.on_prompt() on the agent's reply text as a basic output check.
+    When on_outbound is added in ACF v2, this will switch to that hook.
+    """
+
+    def __init__(self, firewall: Optional[Firewall] = None, **kwargs):
+        _check_ak()
+        super().__init__(**kwargs)
+        self._firewall = firewall or Firewall()
+
+    def validate(
+        self,
+        agent: Agent,
+        session: Session,
+        request: AgentRequestText,
+        reply: AgentReplyAny,
+    ) -> GuardrailResult:
+        """Check agent output through the ACF firewall."""
+        text = None
+        if isinstance(reply, AgentReplyText):
+            text = reply.response
+        elif hasattr(reply, "response"):
+            text = str(reply.response)
+
+        if not text:
+            return GuardrailResult(action=GuardrailAction.ALLOW)
+
+        try:
+            result = self._firewall.on_prompt(text)
+        except FirewallError as e:
+            logger.warning("acf-sdk: guardrail error on output: %s", e)
+            return GuardrailResult(
+                action=GuardrailAction.BLOCK,
+                message=f"ACF firewall error: {e}",
+            )
+
+        if isinstance(result, SanitiseResult):
+            if isinstance(reply, AgentReplyText):
+                reply.response = result.sanitised_text
+            return GuardrailResult(
+                action=GuardrailAction.OVERRIDE,
+                override_text=result.sanitised_text,
+                message="ACF: output sanitised",
+            )
+
+        if result == Decision.BLOCK:
+            return GuardrailResult(
+                action=GuardrailAction.BLOCK,
+                message="ACF: output blocked by firewall policy",
+            )
+
+        return GuardrailResult(action=GuardrailAction.ALLOW)
+
+
+# Register with Agent Kernel's factory so users can just set
+# provider: acf in their config.
+if _AK_AVAILABLE:
+    try:
+        InputGuardrailFactory.register("acf", ACFInputGuardrail)
+        OutputGuardrailFactory.register("acf", ACFOutputGuardrail)
+    except Exception:
+        # Factory might not support registration at import time in all
+        # versions. Users can still instantiate directly.
+        pass

--- a/sdk/python/tests/adapters/test_agent_kernel.py
+++ b/sdk/python/tests/adapters/test_agent_kernel.py
@@ -1,0 +1,244 @@
+"""
+Tests for the Agent Kernel guardrail adapter.
+
+Mocks agentkernel dependencies so tests run without it installed.
+Verifies decision mapping, error handling, and sanitise override logic.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Mock agentkernel before importing the adapter
+mock_guardrail = MagicMock()
+mock_core_model = MagicMock()
+mock_core_base = MagicMock()
+
+sys.modules["agentkernel"] = MagicMock()
+sys.modules["agentkernel.guardrail"] = MagicMock()
+sys.modules["agentkernel.guardrail.guardrail"] = mock_guardrail
+sys.modules["agentkernel.core"] = MagicMock()
+sys.modules["agentkernel.core.model"] = mock_core_model
+sys.modules["agentkernel.core.base"] = mock_core_base
+
+
+# Define fake classes that the adapter expects
+class FakeGuardrailAction:
+    ALLOW = "ALLOW"
+    BLOCK = "BLOCK"
+    OVERRIDE = "OVERRIDE"
+
+
+class FakeGuardrailResult:
+    def __init__(self, action, message=None, override_text=None):
+        self.action = action
+        self.message = message
+        self.override_text = override_text
+
+
+class FakeInputGuardrail:
+    def __init__(self, **kwargs):
+        pass
+
+
+class FakeOutputGuardrail:
+    def __init__(self, **kwargs):
+        pass
+
+
+class FakeInputGuardrailFactory:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name, klass):
+        cls._registry[name] = klass
+
+
+class FakeOutputGuardrailFactory:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name, klass):
+        cls._registry[name] = klass
+
+
+class FakeAgentRequestText:
+    def __init__(self, prompt=""):
+        self.prompt = prompt
+
+
+class FakeAgentReplyText:
+    def __init__(self, response="", prompt=""):
+        self.response = response
+        self.prompt = prompt
+
+
+class FakeAgent:
+    name = "test-agent"
+
+
+class FakeSession:
+    def __init__(self, sid="test-session"):
+        self.id = sid
+
+
+# Wire up the mocks
+mock_guardrail.GuardrailAction = FakeGuardrailAction
+mock_guardrail.GuardrailResult = FakeGuardrailResult
+mock_guardrail.InputGuardrail = FakeInputGuardrail
+mock_guardrail.OutputGuardrail = FakeOutputGuardrail
+mock_guardrail.InputGuardrailFactory = FakeInputGuardrailFactory
+mock_guardrail.OutputGuardrailFactory = FakeOutputGuardrailFactory
+mock_guardrail.BaseGuardrailUtil = MagicMock()
+mock_core_model.AgentRequestText = FakeAgentRequestText
+mock_core_model.AgentReplyText = FakeAgentReplyText
+mock_core_model.AgentReplyAny = FakeAgentReplyText
+mock_core_base.Agent = FakeAgent
+mock_core_base.Session = FakeSession
+
+# Now import the adapter
+from acf.adapters.agent_kernel import ACFInputGuardrail, ACFOutputGuardrail
+from acf.models import Decision, SanitiseResult, FirewallError
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def make_firewall(return_value):
+    """Build a mock Firewall where on_prompt returns the given value."""
+    fw = MagicMock()
+    fw.on_prompt.return_value = return_value
+    return fw
+
+
+def make_request(text="hello"):
+    return FakeAgentRequestText(prompt=text)
+
+
+def make_reply(text="response"):
+    return FakeAgentReplyText(response=text, prompt="query")
+
+
+# ── InputGuardrail tests ─────────────────────────────────────────────────────
+
+
+class TestACFInputGuardrail:
+
+    def test_allow_passes_through(self):
+        fw = make_firewall(Decision.ALLOW)
+        guard = ACFInputGuardrail(firewall=fw)
+        result = guard.validate(FakeAgent(), FakeSession(), [make_request("hi")])
+        assert result.action == FakeGuardrailAction.ALLOW
+
+    def test_block_returns_block(self):
+        fw = make_firewall(Decision.BLOCK)
+        guard = ACFInputGuardrail(firewall=fw)
+        result = guard.validate(FakeAgent(), FakeSession(), [make_request("attack")])
+        assert result.action == FakeGuardrailAction.BLOCK
+        assert "blocked" in result.message.lower()
+
+    def test_sanitise_returns_override(self):
+        sanitised = SanitiseResult(
+            decision=Decision.SANITISE,
+            sanitised_payload=b"clean text",
+            sanitised_text="clean text",
+        )
+        fw = make_firewall(sanitised)
+        guard = ACFInputGuardrail(firewall=fw)
+        req = make_request("dirty text")
+        result = guard.validate(FakeAgent(), FakeSession(), [req])
+        assert result.action == FakeGuardrailAction.OVERRIDE
+        assert result.override_text == "clean text"
+
+    def test_sanitise_updates_request_prompt(self):
+        sanitised = SanitiseResult(
+            decision=Decision.SANITISE,
+            sanitised_payload=b"cleaned",
+            sanitised_text="cleaned",
+        )
+        fw = make_firewall(sanitised)
+        guard = ACFInputGuardrail(firewall=fw)
+        req = make_request("original")
+        guard.validate(FakeAgent(), FakeSession(), [req])
+        assert req.prompt == "cleaned"
+
+    def test_firewall_error_returns_block(self):
+        fw = MagicMock()
+        fw.on_prompt.side_effect = FirewallError("connection failed")
+        guard = ACFInputGuardrail(firewall=fw)
+        result = guard.validate(FakeAgent(), FakeSession(), [make_request("test")])
+        assert result.action == FakeGuardrailAction.BLOCK
+        assert "error" in result.message.lower()
+
+    def test_empty_requests_allows(self):
+        fw = make_firewall(Decision.ALLOW)
+        guard = ACFInputGuardrail(firewall=fw)
+        result = guard.validate(FakeAgent(), FakeSession(), [])
+        assert result.action == FakeGuardrailAction.ALLOW
+
+    def test_non_string_prompt_skipped(self):
+        fw = make_firewall(Decision.ALLOW)
+        guard = ACFInputGuardrail(firewall=fw)
+        req = FakeAgentRequestText(prompt="")
+        result = guard.validate(FakeAgent(), FakeSession(), [req])
+        assert result.action == FakeGuardrailAction.ALLOW
+        fw.on_prompt.assert_not_called()
+
+
+# ── OutputGuardrail tests ────────────────────────────────────────────────────
+
+
+class TestACFOutputGuardrail:
+
+    def test_allow_passes_through(self):
+        fw = make_firewall(Decision.ALLOW)
+        guard = ACFOutputGuardrail(firewall=fw)
+        result = guard.validate(
+            FakeAgent(), FakeSession(), make_request(), make_reply("safe output")
+        )
+        assert result.action == FakeGuardrailAction.ALLOW
+
+    def test_block_returns_block(self):
+        fw = make_firewall(Decision.BLOCK)
+        guard = ACFOutputGuardrail(firewall=fw)
+        result = guard.validate(
+            FakeAgent(), FakeSession(), make_request(), make_reply("dangerous output")
+        )
+        assert result.action == FakeGuardrailAction.BLOCK
+
+    def test_sanitise_returns_override(self):
+        sanitised = SanitiseResult(
+            decision=Decision.SANITISE,
+            sanitised_payload=b"clean output",
+            sanitised_text="clean output",
+        )
+        fw = make_firewall(sanitised)
+        guard = ACFOutputGuardrail(firewall=fw)
+        reply = make_reply("dirty output")
+        result = guard.validate(
+            FakeAgent(), FakeSession(), make_request(), reply
+        )
+        assert result.action == FakeGuardrailAction.OVERRIDE
+        assert reply.response == "clean output"
+
+    def test_empty_reply_allows(self):
+        fw = make_firewall(Decision.ALLOW)
+        guard = ACFOutputGuardrail(firewall=fw)
+        reply = make_reply("")
+        result = guard.validate(
+            FakeAgent(), FakeSession(), make_request(), reply
+        )
+        assert result.action == FakeGuardrailAction.ALLOW
+        fw.on_prompt.assert_not_called()
+
+    def test_firewall_error_returns_block(self):
+        fw = MagicMock()
+        fw.on_prompt.side_effect = FirewallError("sidecar down")
+        guard = ACFOutputGuardrail(firewall=fw)
+        result = guard.validate(
+            FakeAgent(), FakeSession(), make_request(), make_reply("output")
+        )
+        assert result.action == FakeGuardrailAction.BLOCK
+        assert "error" in result.message.lower()


### PR DESCRIPTION
Second framework adapter. Integrates ACF as a guardrail in Agent Kernel (https://github.com/yaalalabs/agent-kernel), sitting alongside their OpenAI and Bedrock guardrail options.

## What it does

Two classes: `ACFInputGuardrail` and `ACFOutputGuardrail`. Both implement Agent Kernel's guardrail interface so ACF plugs in natively.

Decision mapping:
- `Decision.ALLOW` → `GuardrailAction.ALLOW`
- `Decision.BLOCK` → `GuardrailAction.BLOCK`
- `SanitiseResult` → `GuardrailAction.OVERRIDE` (cleaned text replaces original)

Fail-closed on firewall errors. Lazy imports so the base SDK works without agentkernel installed.

Users can configure it in Agent Kernel's config (`provider: acf`) or instantiate directly.

## Why Agent Kernel

It's framework-agnostic — sits above LangGraph, CrewAI, OpenAI Agents SDK, Google ADK. One adapter here means ACF works with all of them through Agent Kernel's runtime.

## Files

- `sdk/python/acf/adapters/agent_kernel.py` — adapter + factory registration
- `sdk/python/tests/adapters/test_agent_kernel.py` — 12 tests, mocks agentkernel deps

## Tests

12/12 adapter tests. Full suite 121/121.