### PR TITLE
test(config): skip symlink test when OS cannot create one

### DIFF
--- a/sidecar/internal/config/loader_test.go
+++ b/sidecar/internal/config/loader_test.go
@@ -83,7 +83,8 @@ func TestLoadResolvesRelativePolicyDirViaConfigSymlink(t *testing.T) {
 	}
 
 	if err := os.Symlink(realConfigDir, linkedConfigDir); err != nil {
-		t.Fatalf("Symlink: %v", err)
+		// Windows without Developer Mode cannot create directory symlinks.
+		t.Skipf("symlink not available: %v", err)
 	}
 
 	configPath := filepath.Join(linkedConfigDir, "sidecar.yaml")


### PR DESCRIPTION
Ran `go test ./...` on Windows 11 without Developer Mode. `TestLoadResolvesRelativePolicyDirViaConfigSymlink` is the only failure — `os.Symlink` needs a privilege most default Windows setups don't have.

Skip that case instead of failing the package. Linux/macOS (and Windows with Developer Mode) still run it.

Related: #18